### PR TITLE
`fixbrackets` function could corrupt link text in some cases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,5 +11,8 @@ let package = Package(
     ],
     targets: [
         .target(name: "HTML2Text", dependencies: ["SwiftSoup"]),
+        .testTarget(
+            name: "HTML2TextTests",
+            dependencies: ["HTML2Text"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,14 @@
-// swift-tools-version:5.0
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "html2text-swift",
+    platforms: [.iOS(.v15), .macOS(.v11)],
     products: [
         .library(name: "HTML2Text", targets: ["HTML2Text"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ttscoff/SwiftSoup.git", from: "2.0.0"),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "HTML2Text", dependencies: ["SwiftSoup"]),

--- a/Sources/HTML2Text/html2text.swift
+++ b/Sources/HTML2Text/html2text.swift
@@ -825,7 +825,8 @@ public class HTML2Text: NodeVisitor {
                     astack.append([:])
                 }
             } else {
-                maybe_automatic_link = nil
+                // resetting on close invalidates auto-links
+                // maybe_automatic_link = nil
                 maybe_linked_image = false
                 if astack.count > 0 {
                     if var a = astack.pop() {

--- a/Sources/HTML2Text/html2text.swift
+++ b/Sources/HTML2Text/html2text.swift
@@ -1466,13 +1466,22 @@ public class HTML2Text: NodeVisitor {
             let group1 = match.group(1) ?? ""
             let group2 = match.group(2) ?? ""
             let group3 = match.group(3) ?? ""
-
+            
             return group1 + "[" + group2 + group3
         }
-
-        // single replacement
-        let text = re.sub(pattern, fixbracket, input) // , re.S)
-
+        
+        var text = input
+        let regex = try! NSRegularExpression(pattern: pattern, options: [])
+        while let match = regex.firstMatch(in: text, options: [], range: NSMakeRange(0, (text as NSString).length)) {
+            let group1 = (text as NSString).substring(with: match.range(at: 1))
+            let group2 = (text as NSString).substring(with: match.range(at: 2))
+            let group3 = (text as NSString).substring(with: match.range(at: 3))
+            var fixbracket = group1 + "[" + group2 + group3
+            for i in 0...9 {
+                fixbracket = fixbracket.replace("\\\(i)", "$\(i)")
+            }
+            text = (text as NSString).replacingCharacters(in: match.range(at: 0), with: fixbracket)
+        }
         return text
     }
 

--- a/Sources/HTML2Text/html2text.swift
+++ b/Sources/HTML2Text/html2text.swift
@@ -278,8 +278,8 @@ public class HTML2Text: NodeVisitor {
 
     /// extract numbering from list element attributes
     public func list_numbering_start(_ attrs: [String: String]) -> Int {
-        if attrs.keys.contains("start") {
-            return Int(attrs["start"]!)! - 1
+        if attrs.keys.contains("start"), let s = attrs["start"], let ix = Int(s) {
+            return ix - 1
         } else {
             return 0
         }

--- a/Sources/HTML2Text/html2text.swift
+++ b/Sources/HTML2Text/html2text.swift
@@ -1457,18 +1457,7 @@ public class HTML2Text: NodeVisitor {
     }
 
     public func fixbrackets(_ input: String) -> String {
-        let pattern = #"(\s*)(`|[\*_]+)\[([^\]]+\1\])"#
-
-        // $1 [$2]$3
-        var fixbracket: String {
-            let match = re.search(pattern, input)
-
-            let group1 = match.group(1) ?? ""
-            let group2 = match.group(2) ?? ""
-            let group3 = match.group(3) ?? ""
-            
-            return group1 + "[" + group2 + group3
-        }
+        let pattern = #"(\s*)(`|[\*_]+)\[([^\]]+\2\])"#
         
         var text = input
         let regex = try! NSRegularExpression(pattern: pattern, options: [])

--- a/Tests/HTML2TextTests/MarkupTests.swift
+++ b/Tests/HTML2TextTests/MarkupTests.swift
@@ -149,4 +149,27 @@ final class MarkupTests: XCTestCase {
         XCTAssert(result == "5. First\n6. Second\n")
     }
 
+    /// Should remain as plain URL
+    func testNakedURL() throws {
+        let html = """
+https://test.com
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "https://test.com\n")
+    }
+    
+    /// Case for `a` tag linking to the matching URL
+    /// Should be renderer as <wrappedURL>
+    func testAutomaticLink() throws {
+        let html = """
+<a href="https://github.com/svnscha/mcp-windbg">https://github.com/svnscha/mcp-windbg</a>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "<https://github.com/svnscha/mcp-windbg>\n")
+    }
+    
 }

--- a/Tests/HTML2TextTests/MarkupTests.swift
+++ b/Tests/HTML2TextTests/MarkupTests.swift
@@ -1,0 +1,111 @@
+//
+//  MarkupTests.swift
+//  
+//
+//  Created by Greg Pierce on 6/7/24.
+//
+
+import XCTest
+@testable import HTML2Text
+
+final class MarkupTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testList() throws {
+        let html = """
+<html>
+<body>
+
+<ul>
+<li>List</li>
+<li>List</li>
+</ul>
+
+</body>
+</html>
+"""
+        let h = HTML2Text(baseurl: "")
+        let result = h.main(data: html)
+        XCTAssert(result == "- List\n- List\n")
+    }
+    
+    func testLink() throws {
+        let html = """
+<html>
+<body>
+
+<a href="https://github.com">GitHub</a>
+
+</body>
+</html>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "[GitHub](https://github.com)\n")
+    }
+    
+    func testListLink() throws {
+        let html = """
+<html>
+<body>
+
+<ul>
+<li><a href="link1">1</a></li>
+<li><a href="link2">2</a></li>
+</ul>
+
+</body>
+</html>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "- [1](link1)\n- [2](link2)\n")
+    }
+    
+    func testListBoldLink() throws {
+        let html = """
+<html>
+<body>
+
+<ul>
+<li><a href="link1"><b>1</b></a></li>
+<li><a href="link2"><b>2</b></a></li>
+</ul>
+
+</body>
+</html>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "- [**1**](link1)\n- [**2**](link2)\n")
+    }
+    
+    func testBoldLink() throws {
+        let html = """
+<a href="t1"><em>1</em></a>
+<a href="t2"><em>2</em></a>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "[_1_](t1) [_2_](t2)\n")
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/HTML2TextTests/MarkupTests.swift
+++ b/Tests/HTML2TextTests/MarkupTests.swift
@@ -90,7 +90,7 @@ final class MarkupTests: XCTestCase {
         XCTAssert(result == "- [**1**](link1)\n- [**2**](link2)\n")
     }
     
-    func testBoldLink() throws {
+    func testEmLink() throws {
         let html = """
 <a href="t1"><em>1</em></a>
 <a href="t2"><em>2</em></a>
@@ -101,11 +101,15 @@ final class MarkupTests: XCTestCase {
         XCTAssert(result == "[_1_](t1) [_2_](t2)\n")
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testLinkEm() throws {
+        let html = """
+<em><a href="t1">1</a></em>
+<em><a href="t2">2</a></em>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "_[1](t1)_ _[2](t2)_\n")
     }
 
 }

--- a/Tests/HTML2TextTests/MarkupTests.swift
+++ b/Tests/HTML2TextTests/MarkupTests.swift
@@ -111,5 +111,16 @@ final class MarkupTests: XCTestCase {
         let result = h.main(data: html)
         XCTAssert(result == "_[1](t1)_ _[2](t2)_\n")
     }
+    
+    func testHeading() throws {
+        let html = """
+<h2><a href="a1">H1</a></h2>
+<h2><a href="a2">H2</a></h2>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "## [H1](a1)\n\n## [H2](a2)\n")
+    }
 
 }

--- a/Tests/HTML2TextTests/MarkupTests.swift
+++ b/Tests/HTML2TextTests/MarkupTests.swift
@@ -122,5 +122,31 @@ final class MarkupTests: XCTestCase {
         let result = h.main(data: html)
         XCTAssert(result == "## [H1](a1)\n\n## [H2](a2)\n")
     }
+    
+    func testEmptyStartAttr() throws {
+        let html = """
+<ol start="">
+<li>First</li>
+<li>Second</li>
+</ol>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "1. First\n2. Second\n")
+    }
+    
+    func testValidStartAttr() throws {
+        let html = """
+<ol start="5">
+<li>First</li>
+<li>Second</li>
+</ol>
+"""
+        let h = HTML2Text(baseurl: "")
+        h.inline_links = true
+        let result = h.main(data: html)
+        XCTAssert(result == "5. First\n6. Second\n")
+    }
 
 }


### PR DESCRIPTION
The `fixbrackets` post-processing function would corrupt link text on some passages. If a single snippet of HTML passed had multiple `<a>` tags with emphasis tags applied to the link text (`em`, `strong`, etc.), the resulting Markdown would use the link text of the first `a` tag for all Markdown links. e.g. `<a href="L1"><em>T1</em></a> <a href="L2"><em>T2</em></a>` would become `[_T1_](L1) [_T1_](L2)`

This pull request rewrites that function to correct this issue, as well as adding a test target and a few unit tests addressing this case.